### PR TITLE
Level transition bug fix

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/LevelOneGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/LevelOneGameArea.java
@@ -477,6 +477,7 @@ public class LevelOneGameArea extends GameArea {
 
     private void retractLowerLadder() {
         isLowerLadderExtended = false;
+        if (isResetting) return;
 
         // Delays disposal of bottom ladder rungs until next frame to avoid physics engine lock
         Gdx.app.postRunnable(() -> {

--- a/source/core/src/main/com/csse3200/game/areas/LevelOneGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/LevelOneGameArea.java
@@ -433,6 +433,7 @@ public class LevelOneGameArea extends GameArea {
 
     private void retractUpperLadder() {
         isUpperLadderExtended = false;
+        if (isResetting) return;
 
         Gdx.app.postRunnable(() -> {
             for (Entity rung : upperLadderBottomSegments) {
@@ -1005,9 +1006,13 @@ public class LevelOneGameArea extends GameArea {
     }
     @Override
     public void dispose() {
+        isResetting = true;
+        retractLowerLadder();
+        retractUpperLadder();
         cancelPlateDebouncers();
         super.dispose();
         ServiceLocator.getResourceService().getAsset(backgroundMusic, Music.class).stop();
         this.unloadAssets();
+        isResetting = false;
     }
 }


### PR DESCRIPTION
# Description

Small bug fix which was missed when reviewing and testing the most recent pr. The bug would cause the game to crash when leaving level one with either of the ladders extended.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Play testing and visual checking

- [x] All current and previous tests pass


# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
