### PR TITLE
FIX: Duplicate component warning at runtime (AutoBomberDrone BombTrackerComponent)

### DIFF
--- a/source/core/src/main/com/csse3200/game/entities/factories/EnemyFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/EnemyFactory.java
@@ -247,8 +247,7 @@ public class EnemyFactory {
         if (patrolRoute != null && patrolRoute.length > 0) {
             drone
                     .addComponent(new SpawnPositionComponent(patrolRoute[0]))
-                    .addComponent(new PatrolRouteComponent(patrolRoute))
-                    .addComponent(new BombTrackerComponent());
+                    .addComponent(new PatrolRouteComponent(patrolRoute));
         }
 
         AnimationRenderComponent animator =


### PR DESCRIPTION
# Description
Tiny patch to remove an extra line in `EnemyFactory.createAutoBomberDrone` that was adding a second `BombTrackerComponent` to the entity.

Resolves first runtime error:
<img width="2418" height="246" alt="image" src="https://github.com/user-attachments/assets/69787d87-287f-4922-a958-609c4569960d" />

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Changes:
* Deletion of ONE line where `BombTrackerComponent` is added to drone entity a second time in `EnemyFactory.createAutoBomberDrone`.

Result:
* Resolve duplicate component warning
* Only a single `BombTrackerComponent` is attached per entity

# How Has This Been Tested?

- [x] Passing unit tests

- [x] Confirm no duplicate component warnings appear in logs

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
